### PR TITLE
chore: Bastion relay templates + binary

### DIFF
--- a/infrastructure/community-relay-cloudformation.yaml
+++ b/infrastructure/community-relay-cloudformation.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Description: "Harbor Community Relay Server - NAT traversal + community boards with storage"
+Description: "Bastion Enclave Relay — NAT traversal + community boards with Isnad auth gate"
 
 Metadata:
   AWS::CloudFormation::Interface:
@@ -13,12 +13,13 @@ Metadata:
           default: "Relay Configuration"
         Parameters:
           - RelayPort
+          - AuthPort
           - MaxReservations
           - MaxCircuits
       - Label:
-          default: "Community Configuration"
+          default: "Enclave Configuration"
         Parameters:
-          - CommunityName
+          - EnclaveName
 
 Parameters:
   InstanceType:
@@ -43,6 +44,13 @@ Parameters:
     MaxValue: 65535
     Description: "Port for the libp2p relay server"
 
+  AuthPort:
+    Type: Number
+    Default: 4002
+    MinValue: 1024
+    MaxValue: 65535
+    Description: "Port for the Isnad auth gate HTTP endpoint"
+
   MaxReservations:
     Type: Number
     Default: 128
@@ -53,10 +61,10 @@ Parameters:
     Default: 16
     Description: "Maximum number of active relay circuits per peer"
 
-  CommunityName:
+  EnclaveName:
     Type: String
-    Default: "Harbor Community"
-    Description: "Name for your community (shown to peers who join)"
+    Default: "Bastion Enclave"
+    Description: "Name for your enclave (shown to peers who join)"
 
 Conditions:
   HasKeyPair: !Not [!Equals [!Ref KeyPairName, ""]]
@@ -126,7 +134,7 @@ Resources:
   RelaySecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: !Sub "Security group for ${AWS::StackName} Harbor community relay server"
+      GroupDescription: !Sub "Security group for ${AWS::StackName} Bastion enclave relay"
       VpcId: !Ref RelayVPC
       SecurityGroupIngress:
         # libp2p relay port (TCP)
@@ -141,6 +149,12 @@ Resources:
           ToPort: !Ref RelayPort
           CidrIp: 0.0.0.0/0
           Description: libp2p relay UDP/QUIC
+        # Isnad auth gate HTTP
+        - IpProtocol: tcp
+          FromPort: !Ref AuthPort
+          ToPort: !Ref AuthPort
+          CidrIp: 0.0.0.0/0
+          Description: Isnad auth gate HTTP
         # SSH access (only if key pair provided)
         - IpProtocol: tcp
           FromPort: 22
@@ -159,12 +173,12 @@ Resources:
   RelayAddressParameter:
     Type: AWS::SSM::Parameter
     Properties:
-      Name: !Sub "/harbor/${AWS::StackName}/relay-address"
+      Name: !Sub "/bastion/${AWS::StackName}/relay-address"
       Type: String
       Value: "Starting up... check back in 2 minutes"
-      Description: !Sub "Full relay address for Harbor (${AWS::StackName}) - copy this into the app"
+      Description: !Sub "Full relay address for Bastion (${AWS::StackName}) - copy this into the app"
       Tags:
-        Application: harbor-chat
+        Application: bastion
 
   # IAM Role for EC2
   RelayInstanceRole:
@@ -187,7 +201,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - ssm:PutParameter
-                Resource: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/harbor/${AWS::StackName}/relay-address"
+                Resource: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/bastion/${AWS::StackName}/relay-address"
       Tags:
         - Key: Name
           Value: !Sub "${AWS::StackName}-role"
@@ -238,24 +252,25 @@ Resources:
           #!/bin/bash -xe
           exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 
-          echo "=== Starting Harbor Community Relay Setup ==="
+          echo "=== Starting Bastion Enclave Relay Setup ==="
           echo "Region: ${AWS::Region}"
           echo "Stack: ${AWS::StackName}"
           echo "RelayPort: ${RelayPort}"
-          echo "CommunityName: ${CommunityName}"
+          echo "AuthPort: ${AuthPort}"
+          echo "EnclaveName: ${EnclaveName}"
 
-          EXPECTED_SHA256="c5dcb143d69558107ced27a0dfd30542a88a69906aa53404d9b31ef97a1c66a3"
-          BINARY_URL="https://github.com/bakobiibizo/harbor/raw/main/relay-server/bin/harbor-relay"
+          EXPECTED_SHA256="f374844243abdae916761d2f262ec3d8b89e49a566c676838b8d34c6a5c00bb6"
+          BINARY_URL="https://github.com/bakobiibizo/bastion/raw/main/relay-server/bin/bastion-relay"
           RELAY_PEER_ID="12D3KooWHi81G15poZuH4BL5WnifQ3b2S2uSkvsa1wAhBZNA8PW9"
           IDENTITY_KEY_B64="CAESQKx8WZyvKhxB8KflROQ4EB1jdu+FabKRVVTRo99ulO0wdUP+7I9QeNCLNS8XaxV4JejWR1himdtbElg2ImtLBXo="
 
           # Download pre-compiled binary
           echo "Downloading pre-compiled relay binary..."
-          curl -L -o /usr/local/bin/harbor-relay "$BINARY_URL"
+          curl -L -o /usr/local/bin/bastion-relay "$BINARY_URL"
 
           # Verify SHA256 hash
           echo "Verifying binary integrity..."
-          ACTUAL_SHA256=$(sha256sum /usr/local/bin/harbor-relay | awk '{print $1}')
+          ACTUAL_SHA256=$(sha256sum /usr/local/bin/bastion-relay | awk '{print $1}')
           if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then
             echo "ERROR: SHA256 mismatch!"
             echo "  Expected: $EXPECTED_SHA256"
@@ -264,17 +279,17 @@ Resources:
           fi
           echo "SHA256 verified OK"
 
-          chmod +x /usr/local/bin/harbor-relay
+          chmod +x /usr/local/bin/bastion-relay
 
           # Install static identity key (same peer ID across restarts/redeployments)
           echo "Installing static relay identity key..."
-          mkdir -p /root/.config/harbor-relay
-          echo "$IDENTITY_KEY_B64" | base64 -d > /root/.config/harbor-relay/id.key
+          mkdir -p /root/.config/bastion-relay
+          echo "$IDENTITY_KEY_B64" | base64 -d > /root/.config/bastion-relay/id.key
           echo "Relay Peer ID: $RELAY_PEER_ID"
 
           # Create data directory for SQLite storage
           echo "Creating data directory..."
-          mkdir -p /var/lib/harbor-relay/data
+          mkdir -p /var/lib/bastion-relay/data
 
           # Get public IP using IMDSv2
           echo "Getting public IP..."
@@ -287,11 +302,11 @@ Resources:
           fi
           echo "Public IP: $PUBLIC_IP"
 
-          # Create systemd service (community mode with --community flag)
+          # Create systemd service (enclave mode with Isnad auth gate)
           echo "Creating systemd service..."
-          cat > /etc/systemd/system/libp2p-relay.service << SERVICEEOF
+          cat > /etc/systemd/system/bastion-relay.service << SERVICEEOF
           [Unit]
-          Description=Harbor Community Relay Server
+          Description=Bastion Enclave Relay
           After=network.target
 
           [Service]
@@ -299,7 +314,7 @@ Resources:
           Restart=always
           RestartSec=10
           Environment=RUST_LOG=info
-          ExecStart=/usr/local/bin/harbor-relay --port ${RelayPort} --announce-ip $PUBLIC_IP --max-reservations ${MaxReservations} --max-circuits-per-peer ${MaxCircuits} --community --community-name "${CommunityName}" --data-dir /var/lib/harbor-relay/data
+          ExecStart=/usr/local/bin/bastion-relay --port ${RelayPort} --auth-port ${AuthPort} --announce-ip $PUBLIC_IP --max-reservations ${MaxReservations} --max-circuits-per-peer ${MaxCircuits} --enclave --enclave-name "${EnclaveName}" --data-dir /var/lib/bastion-relay/data
           StandardOutput=journal
           StandardError=journal
 
@@ -310,17 +325,17 @@ Resources:
           # Start the relay service
           echo "Starting relay service..."
           systemctl daemon-reload
-          systemctl enable libp2p-relay
-          systemctl start libp2p-relay
+          systemctl enable bastion-relay
+          systemctl start bastion-relay
 
           # Wait for startup
           echo "Waiting for relay to start (10 seconds)..."
           sleep 10
 
-          systemctl status libp2p-relay --no-pager || true
+          systemctl status bastion-relay --no-pager || true
 
           # Build relay address using known peer ID (no need to extract from logs)
-          SSM_PARAM_NAME="/harbor/${AWS::StackName}/relay-address"
+          SSM_PARAM_NAME="/bastion/${AWS::StackName}/relay-address"
           RELAY_ADDRESS="/ip4/$PUBLIC_IP/tcp/${RelayPort}/p2p/$RELAY_PEER_ID"
 
           echo "Relay address: $RELAY_ADDRESS"
@@ -333,33 +348,38 @@ Resources:
             --region ${AWS::Region}
 
           echo "=== SUCCESS ==="
-          echo "YOUR RELAY ADDRESS (copy this to Harbor):"
+          echo "YOUR RELAY ADDRESS:"
           echo "$RELAY_ADDRESS"
-          echo "Community: ${CommunityName}"
+          echo "Enclave: ${EnclaveName}"
+          echo "Auth gate: http://$PUBLIC_IP:${AuthPort}"
           echo "=== Setup Complete ==="
 
       Tags:
         - Key: Name
           Value: !Sub "${AWS::StackName}-server"
         - Key: Application
-          Value: harbor-chat
+          Value: bastion
 
 Outputs:
   RelayAddress:
     Description: "Your relay address (once the EIP is assigned)"
     Value: !Sub "/ip4/${RelayEIP}/tcp/${RelayPort}/p2p/12D3KooWHi81G15poZuH4BL5WnifQ3b2S2uSkvsa1wAhBZNA8PW9"
 
+  AuthGateURL:
+    Description: "Isnad auth gate endpoint"
+    Value: !Sub "http://${RelayEIP}:${AuthPort}"
+
   Step1WaitTwoMinutes:
     Description: "STEP 1: Wait ~1 minute for the server to start"
     Value: "Uses pre-compiled binary with static identity - starts quickly."
 
   Step2CopyRelayAddress:
-    Description: "STEP 2: Copy the RelayAddress output above into Harbor"
+    Description: "STEP 2: Copy the RelayAddress output above"
     Value: "Paste it into Network > Advanced > Add Relay Address"
 
-  CommunityNameOutput:
-    Description: "Community name"
-    Value: !Ref CommunityName
+  EnclaveNameOutput:
+    Description: "Enclave name"
+    Value: !Ref EnclaveName
 
   RelayPublicIP:
     Description: "Public IP address (for reference)"

--- a/infrastructure/libp2p-relay-cloudformation.yaml
+++ b/infrastructure/libp2p-relay-cloudformation.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Description: "Harbor Relay Server (Lightweight) - NAT traversal only, no community boards or storage"
+Description: "Bastion Relay (Lightweight) — NAT traversal only, no enclave boards or storage"
 
 Metadata:
   AWS::CloudFormation::Interface:
@@ -62,7 +62,7 @@ Resources:
       EnableDnsHostnames: true
       Tags:
         - Key: Name
-          Value: harbor-relay-vpc
+          Value: !Sub "${AWS::StackName}-vpc"
 
   # Internet Gateway
   InternetGateway:
@@ -70,7 +70,7 @@ Resources:
     Properties:
       Tags:
         - Key: Name
-          Value: harbor-relay-igw
+          Value: !Sub "${AWS::StackName}-igw"
 
   VPCGatewayAttachment:
     Type: AWS::EC2::VPCGatewayAttachment
@@ -88,7 +88,7 @@ Resources:
       AvailabilityZone: !Select [0, !GetAZs ""]
       Tags:
         - Key: Name
-          Value: harbor-relay-public-subnet
+          Value: !Sub "${AWS::StackName}-public-subnet"
 
   # Route Table
   PublicRouteTable:
@@ -97,7 +97,7 @@ Resources:
       VpcId: !Ref RelayVPC
       Tags:
         - Key: Name
-          Value: harbor-relay-public-rt
+          Value: !Sub "${AWS::StackName}-public-rt"
 
   PublicRoute:
     Type: AWS::EC2::Route
@@ -117,8 +117,7 @@ Resources:
   RelaySecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupName: harbor-relay-sg
-      GroupDescription: Security group for Harbor libp2p relay server
+      GroupDescription: !Sub "Security group for ${AWS::StackName} Bastion relay"
       VpcId: !Ref RelayVPC
       SecurityGroupIngress:
         # libp2p relay port (TCP)
@@ -145,24 +144,23 @@ Resources:
           Description: Allow all outbound
       Tags:
         - Key: Name
-          Value: harbor-relay-sg
+          Value: !Sub "${AWS::StackName}-sg"
 
   # SSM Parameter to store the relay address (so users can easily find it)
   RelayAddressParameter:
     Type: AWS::SSM::Parameter
     Properties:
-      Name: /harbor/relay-address
+      Name: !Sub "/bastion/${AWS::StackName}/relay-address"
       Type: String
       Value: "Starting up... check back in 5 minutes"
-      Description: "Full relay address for Harbor - copy this into the app"
+      Description: !Sub "Full relay address for Bastion (${AWS::StackName})"
       Tags:
-        Application: harbor-chat
+        Application: bastion
 
   # IAM Role for EC2 (for SSM access + parameter store write)
   RelayInstanceRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: harbor-relay-instance-role
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -180,15 +178,14 @@ Resources:
               - Effect: Allow
                 Action:
                   - ssm:PutParameter
-                Resource: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/harbor/relay-address"
+                Resource: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/bastion/${AWS::StackName}/relay-address"
       Tags:
         - Key: Name
-          Value: harbor-relay-role
+          Value: !Sub "${AWS::StackName}-role"
 
   RelayInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
-      InstanceProfileName: harbor-relay-instance-profile
       Roles:
         - !Ref RelayInstanceRole
 
@@ -199,20 +196,19 @@ Resources:
       Domain: vpc
       Tags:
         - Key: Name
-          Value: harbor-relay-eip
+          Value: !Sub "${AWS::StackName}-eip"
 
   EIPAssociation:
     Type: AWS::EC2::EIPAssociation
     Properties:
       InstanceId: !Ref RelayInstance
-      EIP: !Ref RelayEIP
+      AllocationId: !GetAtt RelayEIP.AllocationId
 
   # EC2 Instance
   RelayInstance:
     Type: AWS::EC2::Instance
     Properties:
       InstanceType: !Ref InstanceType
-      # Use SSM Parameter to always get the latest Amazon Linux 2023 AMI
       ImageId: !Sub "{{resolve:ssm:/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64}}"
       KeyName: !If [HasKeyPair, !Ref KeyPairName, !Ref "AWS::NoValue"]
       IamInstanceProfile: !Ref RelayInstanceProfile
@@ -233,7 +229,7 @@ Resources:
           #!/bin/bash -xe
           exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 
-          echo "=== Starting Harbor Relay Setup ==="
+          echo "=== Starting Bastion Relay Setup ==="
           echo "Region: ${AWS::Region}"
           echo "RelayPort: ${RelayPort}"
 
@@ -254,12 +250,11 @@ Resources:
           echo "Creating /opt/relay directory..."
           mkdir -p /opt/relay
 
-          # Get public IP using IMDSv2 (required on newer Amazon Linux AMIs)
+          # Get public IP using IMDSv2
           echo "Getting public IP using IMDSv2..."
           IMDS_TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" 2>/dev/null)
           PUBLIC_IP=$(curl -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" http://169.254.169.254/latest/meta-data/public-ipv4 2>/dev/null)
 
-          # Fallback to external IP service if IMDS fails
           if [ -z "$PUBLIC_IP" ] || echo "$PUBLIC_IP" | grep -q "<?xml"; then
             echo "IMDSv2 failed, trying external IP service..."
             PUBLIC_IP=$(curl -s https://checkip.amazonaws.com 2>/dev/null | tr -d '\n')
@@ -267,25 +262,25 @@ Resources:
 
           echo "Public IP: $PUBLIC_IP"
 
-          # Clone Harbor repo and build relay server
-          echo "Cloning Harbor repository..."
+          # Clone Bastion repo and build relay server
+          echo "Cloning Bastion repository..."
           cd /opt/relay
-          git clone --depth 1 https://github.com/bakobiibizo/harbor.git
+          git clone --depth 1 https://github.com/bakobiibizo/bastion.git
 
           echo "Building relay server (this may take a few minutes)..."
-          cd /opt/relay/harbor/relay-server
+          cd /opt/relay/bastion/relay-server
           source /root/.cargo/env
           cargo build --release
 
           # Copy binary to /usr/local/bin
-          cp /opt/relay/harbor/relay-server/target/release/harbor-relay /usr/local/bin/
-          chmod +x /usr/local/bin/harbor-relay
+          cp /opt/relay/bastion/relay-server/target/release/bastion-relay /usr/local/bin/
+          chmod +x /usr/local/bin/bastion-relay
 
           # Create systemd service
           echo "Creating systemd service..."
-          cat > /etc/systemd/system/libp2p-relay.service << SERVICEEOF
+          cat > /etc/systemd/system/bastion-relay.service << SERVICEEOF
           [Unit]
-          Description=Harbor libp2p Relay Server
+          Description=Bastion libp2p Relay
           After=network.target
 
           [Service]
@@ -293,7 +288,7 @@ Resources:
           Restart=always
           RestartSec=10
           Environment=RUST_LOG=info
-          ExecStart=/usr/local/bin/harbor-relay --port ${RelayPort} --announce-ip $PUBLIC_IP --max-reservations ${MaxReservations} --max-circuits-per-peer ${MaxCircuits}
+          ExecStart=/usr/local/bin/bastion-relay --port ${RelayPort} --announce-ip $PUBLIC_IP --max-reservations ${MaxReservations} --max-circuits-per-peer ${MaxCircuits}
           StandardOutput=journal
           StandardError=journal
 
@@ -304,24 +299,22 @@ Resources:
           # Enable and start the relay service
           echo "Starting relay service..."
           systemctl daemon-reload
-          systemctl enable libp2p-relay
-          systemctl start libp2p-relay
+          systemctl enable bastion-relay
+          systemctl start bastion-relay
 
           # Wait for the relay to fully start
           echo "Waiting for relay to start (30 seconds)..."
           sleep 30
 
-          # Check relay service status
           echo "Checking relay service status..."
-          systemctl status libp2p-relay --no-pager || true
+          systemctl status bastion-relay --no-pager || true
 
           # Get the peer ID from journalctl logs
-          # The Rust relay server logs "Local Peer ID: 12D3KooW..."
           echo "Getting peer ID from logs..."
           PEER_ID=""
           for i in {1..30}; do
             echo "Attempt $i to get peer ID..."
-            PEER_ID=$(journalctl -u libp2p-relay --no-pager 2>&1 | grep -oE '(12D3KooW|Qm)[a-zA-Z0-9]+' | head -1)
+            PEER_ID=$(journalctl -u bastion-relay --no-pager 2>&1 | grep -oE '(12D3KooW|Qm)[a-zA-Z0-9]+' | head -1)
             if [ -n "$PEER_ID" ]; then
               echo "Found Peer ID: $PEER_ID"
               echo "$PEER_ID" > /opt/relay/peer-id.txt
@@ -332,28 +325,23 @@ Resources:
 
           if [ -z "$PEER_ID" ]; then
             echo "WARNING: Could not extract peer ID from logs"
-            echo "Journal logs:"
-            journalctl -u libp2p-relay --no-pager | tail -50
+            journalctl -u bastion-relay --no-pager | tail -50
           fi
-
-          # PUBLIC_IP was already retrieved earlier
 
           # Build relay address
           if [ -n "$PEER_ID" ] && [ -n "$PUBLIC_IP" ]; then
             RELAY_ADDRESS="/ip4/$PUBLIC_IP/tcp/${RelayPort}/p2p/$PEER_ID"
             echo "Relay address: $RELAY_ADDRESS"
 
-            # Write to SSM Parameter Store
-            echo "Writing to SSM Parameter Store..."
             aws ssm put-parameter \
-              --name "/harbor/relay-address" \
+              --name "/bastion/${AWS::StackName}/relay-address" \
               --value "$RELAY_ADDRESS" \
               --type String \
               --overwrite \
               --region ${AWS::Region}
 
             echo "=== SUCCESS ==="
-            echo "YOUR RELAY ADDRESS (copy this to Harbor):"
+            echo "YOUR RELAY ADDRESS:"
             echo "$RELAY_ADDRESS"
           else
             echo "=== PARTIAL FAILURE ==="
@@ -361,9 +349,8 @@ Resources:
             echo "Public IP: $PUBLIC_IP"
             echo "Peer ID: $PEER_ID"
 
-            # Write error to SSM so user knows something went wrong
             aws ssm put-parameter \
-              --name "/harbor/relay-address" \
+              --name "/bastion/${AWS::StackName}/relay-address" \
               --value "ERROR: Setup incomplete. Check /var/log/user-data.log on EC2 instance" \
               --type String \
               --overwrite \
@@ -371,25 +358,24 @@ Resources:
           fi
 
           echo "=== Setup Complete ==="
-          echo "Log file: /var/log/user-data.log"
 
       Tags:
         - Key: Name
-          Value: harbor-relay-server
+          Value: !Sub "${AWS::StackName}-server"
         - Key: Application
-          Value: harbor-chat
+          Value: bastion
 
 Outputs:
   Step1WaitFiveMinutes:
-    Description: "STEP 1: Wait 5 minutes for the server to start up"
-    Value: "The relay server needs about 5 minutes to fully start. Grab a coffee!"
+    Description: "STEP 1: Wait 5 minutes for the server to build and start"
+    Value: "The relay server needs about 5 minutes to compile from source."
 
   Step2GetYourRelayAddress:
     Description: "STEP 2: Click this link to get your relay address"
-    Value: !Sub "https://${AWS::Region}.console.aws.amazon.com/systems-manager/parameters/harbor/relay-address/description?region=${AWS::Region}"
+    Value: !Sub "https://${AWS::Region}.console.aws.amazon.com/systems-manager/parameters/bastion/${AWS::StackName}/relay-address/description?region=${AWS::Region}"
 
   Step3CopyTheValue:
-    Description: "STEP 3: Copy the 'Value' field and paste it into Harbor"
+    Description: "STEP 3: Copy the 'Value' field and paste it into Bastion"
     Value: "On that page, find the 'Value' field. It looks like: /ip4/1.2.3.4/tcp/4001/p2p/12D3KooW..."
 
   RelayPublicIP:

--- a/relay-server/bin/bastion-relay.sha256
+++ b/relay-server/bin/bastion-relay.sha256
@@ -1,0 +1,1 @@
+f374844243abdae916761d2f262ec3d8b89e49a566c676838b8d34c6a5c00bb6  relay-server/bin/bastion-relay

--- a/relay-server/docker-compose.yml
+++ b/relay-server/docker-compose.yml
@@ -1,23 +1,25 @@
-version: '3.8'
-
 services:
-  harbor-relay:
+  bastion-relay:
     build: .
-    image: harbor-relay:latest
-    container_name: harbor-relay
+    image: bastion-relay:latest
+    container_name: bastion-relay
     restart: unless-stopped
     environment:
       - RUST_LOG=info
-      - IDENTITY_KEY_PATH=/var/lib/harbor-relay/id.key
+      - IDENTITY_KEY_PATH=/var/lib/bastion-relay/id.key
     command: >
       --port 4001
       --announce-ip ${ANNOUNCE_IP:-154.5.126.219}
-      --identity-key-path /var/lib/harbor-relay/id.key
+      --identity-key-path /var/lib/bastion-relay/id.key
+      --enclave
+      --enclave-name "${ENCLAVE_NAME:-Bastion}"
+      --data-dir /var/lib/bastion-relay/data
     ports:
       - "4001:4001/tcp"
       - "4001:4001/udp"
+      - "4002:4002/tcp"
     volumes:
-      - relay-data:/var/lib/harbor-relay
+      - relay-data:/var/lib/bastion-relay
 
 volumes:
   relay-data:

--- a/scripts/build-relay.sh
+++ b/scripts/build-relay.sh
@@ -13,12 +13,12 @@ cargo build --release --manifest-path "$RELAY_DIR/Cargo.toml"
 
 echo "[+] Copying binary to $BIN_DIR..."
 mkdir -p "$BIN_DIR"
-cp "$RELAY_DIR/target/release/harbor-relay" "$BIN_DIR/harbor-relay"
+cp "$RELAY_DIR/target/release/bastion-relay" "$BIN_DIR/bastion-relay"
 
 echo "[+] Computing SHA256..."
-SHA256=$(sha256sum "$BIN_DIR/harbor-relay" | awk '{print $1}')
-echo "$SHA256  relay-server/bin/harbor-relay" > "$BIN_DIR/harbor-relay.sha256"
+SHA256=$(sha256sum "$BIN_DIR/bastion-relay" | awk '{print $1}')
+echo "$SHA256  relay-server/bin/bastion-relay" > "$BIN_DIR/bastion-relay.sha256"
 
 echo "[+] Done."
-echo "    Binary: $BIN_DIR/harbor-relay"
+echo "    Binary: $BIN_DIR/bastion-relay"
 echo "    SHA256: $SHA256"


### PR DESCRIPTION
## Summary
- Renamed all relay infrastructure from Harbor to Bastion
- CloudFormation templates use Bastion naming, paths, SSM parameters
- Community template renamed to **Enclave** template with Isnad auth gate
  - Added `AuthPort` parameter (default 4002)
  - Security group opens auth gate port
  - Auth gate URL in outputs
- Systemd service: `bastion-relay.service`
- Docker compose: enclave mode enabled by default, auth port exposed
- Fresh relay binary built from current source with updated SHA256
- Build script outputs `bastion-relay` binary

## Files changed
- `infrastructure/community-relay-cloudformation.yaml` — enclave template
- `infrastructure/libp2p-relay-cloudformation.yaml` — lightweight template
- `relay-server/docker-compose.yml` — enclave mode + auth port
- `relay-server/bin/bastion-relay` — new binary
- `relay-server/bin/bastion-relay.sha256` — integrity hash
- `scripts/build-relay.sh` — updated binary name

## Test plan
- [ ] Deploy enclave template to AWS — verify startup, SQLite init, auth gate
- [ ] `docker compose up` with relay — verify enclave mode + storage
- [ ] Agent connects, solves CAPTCHA, posts to board

🤖 Generated with [Claude Code](https://claude.com/claude-code)